### PR TITLE
Add basic patient management views

### DIFF
--- a/PatientApp/DAL/AppDbContext.cs
+++ b/PatientApp/DAL/AppDbContext.cs
@@ -1,0 +1,25 @@
+using Microsoft.EntityFrameworkCore;
+using PatientApp.Models;
+using System;
+using System.IO;
+
+namespace PatientApp.DAL;
+
+public class AppDbContext : DbContext
+{
+    public DbSet<Patient> Patients => Set<Patient>();
+    public DbSet<Procedure> Procedures => Set<Procedure>();
+    public DbSet<Visit> Visits => Set<Visit>();
+    public DbSet<VisitProcedure> VisitProcedures => Set<VisitProcedure>();
+
+    protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
+    {
+        var path = Path.Combine(System.AppContext.BaseDirectory, "patientapp.db");
+        optionsBuilder.UseSqlite($"Data Source={path}");
+    }
+
+    protected override void OnModelCreating(ModelBuilder modelBuilder)
+    {
+        base.OnModelCreating(modelBuilder);
+    }
+}

--- a/PatientApp/DAL/DataService.cs
+++ b/PatientApp/DAL/DataService.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using PatientApp.Models;
+
+namespace PatientApp.DAL;
+
+public class DataService
+{
+    public DataService()
+    {
+        using var db = new AppDbContext();
+        db.Database.EnsureCreated();
+    }
+
+    public List<Patient> GetPatients()
+    {
+        using var db = new AppDbContext();
+        return db.Patients.Include(p => p.Visits).ToList();
+    }
+
+    public void AddPatient(Patient patient)
+    {
+        using var db = new AppDbContext();
+        db.Patients.Add(patient);
+        db.SaveChanges();
+    }
+
+    public List<Procedure> GetProcedures()
+    {
+        using var db = new AppDbContext();
+        return db.Procedures.ToList();
+    }
+
+    public void AddProcedure(Procedure procedure)
+    {
+        using var db = new AppDbContext();
+        db.Procedures.Add(procedure);
+        db.SaveChanges();
+    }
+}

--- a/PatientApp/Models/Patient.cs
+++ b/PatientApp/Models/Patient.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace PatientApp.Models;
+
+public class Patient
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public string FullName { get; set; } = string.Empty;
+
+    public DateTime? BirthDate { get; set; }
+
+    public string? ContactInfo { get; set; }
+
+    public ICollection<Visit> Visits { get; set; } = new List<Visit>();
+}

--- a/PatientApp/Models/Procedure.cs
+++ b/PatientApp/Models/Procedure.cs
@@ -1,0 +1,19 @@
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace PatientApp.Models;
+
+public class Procedure
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public string Name { get; set; } = string.Empty;
+
+    public string? Description { get; set; }
+
+    public decimal Cost { get; set; }
+
+    public ICollection<VisitProcedure> VisitProcedures { get; set; } = new List<VisitProcedure>();
+}

--- a/PatientApp/Models/Visit.cs
+++ b/PatientApp/Models/Visit.cs
@@ -1,0 +1,37 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace PatientApp.Models;
+
+public class Visit
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required, ForeignKey(nameof(Patient))]
+    public int PatientId { get; set; }
+
+    public Patient Patient { get; set; } = null!;
+
+    public DateTime VisitDate { get; set; } = DateTime.Now;
+
+    public ICollection<VisitProcedure> VisitProcedures { get; set; } = new List<VisitProcedure>();
+
+    public decimal? TotalCost { get; set; }
+}
+
+public class VisitProcedure
+{
+    [Key]
+    public int Id { get; set; }
+
+    [ForeignKey(nameof(Visit))]
+    public int VisitId { get; set; }
+    public Visit Visit { get; set; } = null!;
+
+    [ForeignKey(nameof(Procedure))]
+    public int ProcedureId { get; set; }
+    public Procedure Procedure { get; set; } = null!;
+}

--- a/PatientApp/PatientApp.csproj
+++ b/PatientApp/PatientApp.csproj
@@ -24,5 +24,7 @@
             <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
         </PackageReference>
         <PackageReference Include="Avalonia.ReactiveUI" Version="11.3.2"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.0"/>
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="8.0.0"/>
     </ItemGroup>
 </Project>

--- a/PatientApp/ViewModels/AddPatientViewModel.cs
+++ b/PatientApp/ViewModels/AddPatientViewModel.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Reactive;
+using ReactiveUI;
+using PatientApp.Models;
+using PatientApp.DAL;
+
+namespace PatientApp.ViewModels;
+
+public class AddPatientViewModel : ViewModelBase
+{
+    private readonly DataService _dataService = new();
+
+    public string FullName { get; set; } = string.Empty;
+    public DateTime? BirthDate { get; set; }
+    public string? ContactInfo { get; set; }
+
+    public ReactiveCommand<Unit, Unit> SaveCommand { get; }
+
+    public AddPatientViewModel()
+    {
+        SaveCommand = ReactiveCommand.Create(Save);
+    }
+
+    private void Save()
+    {
+        var patient = new Patient
+        {
+            FullName = FullName,
+            BirthDate = BirthDate,
+            ContactInfo = ContactInfo
+        };
+        _dataService.AddPatient(patient);
+    }
+}

--- a/PatientApp/ViewModels/AddProcedureViewModel.cs
+++ b/PatientApp/ViewModels/AddProcedureViewModel.cs
@@ -1,0 +1,33 @@
+using System.Reactive;
+using ReactiveUI;
+using PatientApp.DAL;
+using PatientApp.Models;
+
+namespace PatientApp.ViewModels;
+
+public class AddProcedureViewModel : ViewModelBase
+{
+    private readonly DataService _dataService = new();
+
+    public string Name { get; set; } = string.Empty;
+    public string? Description { get; set; }
+    public decimal Cost { get; set; }
+
+    public ReactiveCommand<Unit, Unit> SaveCommand { get; }
+
+    public AddProcedureViewModel()
+    {
+        SaveCommand = ReactiveCommand.Create(Save);
+    }
+
+    private void Save()
+    {
+        var proc = new Procedure
+        {
+            Name = Name,
+            Description = Description,
+            Cost = Cost
+        };
+        _dataService.AddProcedure(proc);
+    }
+}

--- a/PatientApp/ViewModels/MainWindowViewModel.cs
+++ b/PatientApp/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,28 @@
-﻿namespace PatientApp.ViewModels;
+using System.Reactive;
+using ReactiveUI;
+
+namespace PatientApp.ViewModels;
 
 public class MainWindowViewModel : ViewModelBase
 {
-    public string Greeting { get; } = "Welcome to Avalonia!";
+    public ViewModelBase CurrentView { get; private set; }
+
+    public PatientsViewModel PatientsViewModel { get; } = new();
+    public ProceduresViewModel ProceduresViewModel { get; } = new();
+
+    public ReactiveCommand<Unit, Unit> ShowPatientsCommand { get; }
+    public ReactiveCommand<Unit, Unit> ShowProceduresCommand { get; }
+
+    public MainWindowViewModel()
+    {
+        CurrentView = PatientsViewModel;
+        ShowPatientsCommand = ReactiveCommand.Create(() =>
+        {
+            CurrentView = PatientsViewModel;
+        });
+        ShowProceduresCommand = ReactiveCommand.Create(() =>
+        {
+            CurrentView = ProceduresViewModel;
+        });
+    }
 }

--- a/PatientApp/ViewModels/PatientsViewModel.cs
+++ b/PatientApp/ViewModels/PatientsViewModel.cs
@@ -1,0 +1,25 @@
+using System.Collections.ObjectModel;
+using ReactiveUI;
+using PatientApp.Models;
+using PatientApp.DAL;
+
+namespace PatientApp.ViewModels;
+
+public class PatientsViewModel : ViewModelBase
+{
+    private readonly DataService _dataService = new();
+
+    public ObservableCollection<Patient> Patients { get; } = new();
+
+    public PatientsViewModel()
+    {
+        Load();
+    }
+
+    public void Load()
+    {
+        Patients.Clear();
+        foreach (var p in _dataService.GetPatients())
+            Patients.Add(p);
+    }
+}

--- a/PatientApp/ViewModels/ProceduresViewModel.cs
+++ b/PatientApp/ViewModels/ProceduresViewModel.cs
@@ -1,0 +1,23 @@
+using System.Collections.ObjectModel;
+using PatientApp.DAL;
+using PatientApp.Models;
+
+namespace PatientApp.ViewModels;
+
+public class ProceduresViewModel : ViewModelBase
+{
+    private readonly DataService _dataService = new();
+    public ObservableCollection<Procedure> Procedures { get; } = new();
+
+    public ProceduresViewModel()
+    {
+        Load();
+    }
+
+    public void Load()
+    {
+        Procedures.Clear();
+        foreach (var p in _dataService.GetProcedures())
+            Procedures.Add(p);
+    }
+}

--- a/PatientApp/Views/AddPatientView.axaml
+++ b/PatientApp/Views/AddPatientView.axaml
@@ -1,0 +1,15 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="PatientApp.Views.AddPatientView"
+             xmlns:vm="using:PatientApp.ViewModels"
+             x:DataType="vm:AddPatientViewModel">
+    <StackPanel Margin="10" Spacing="5">
+        <TextBox Watermark="Full name" Text="{Binding FullName}"/>
+        <DatePicker SelectedDate="{Binding BirthDate}"/>
+        <TextBox Watermark="Contact info" Text="{Binding ContactInfo}"/>
+        <Button Content="Save" Command="{Binding SaveCommand}"/>
+    </StackPanel>
+</UserControl>

--- a/PatientApp/Views/AddPatientView.axaml.cs
+++ b/PatientApp/Views/AddPatientView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace PatientApp.Views;
+
+public partial class AddPatientView : UserControl
+{
+    public AddPatientView()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/PatientApp/Views/AddProcedureView.axaml
+++ b/PatientApp/Views/AddProcedureView.axaml
@@ -1,0 +1,15 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="PatientApp.Views.AddProcedureView"
+             xmlns:vm="using:PatientApp.ViewModels"
+             x:DataType="vm:AddProcedureViewModel">
+    <StackPanel Margin="10" Spacing="5">
+        <TextBox Watermark="Name" Text="{Binding Name}"/>
+        <TextBox Watermark="Description" Text="{Binding Description}"/>
+        <TextBox Watermark="Cost" Text="{Binding Cost}"/>
+        <Button Content="Save" Command="{Binding SaveCommand}"/>
+    </StackPanel>
+</UserControl>

--- a/PatientApp/Views/AddProcedureView.axaml.cs
+++ b/PatientApp/Views/AddProcedureView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace PatientApp.Views;
+
+public partial class AddProcedureView : UserControl
+{
+    public AddProcedureView()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/PatientApp/Views/MainWindow.axaml
+++ b/PatientApp/Views/MainWindow.axaml
@@ -15,6 +15,12 @@
         <vm:MainWindowViewModel/>
     </Design.DataContext>
 
-    <TextBlock Text="{Binding Greeting}" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    <DockPanel>
+        <StackPanel Orientation="Horizontal" DockPanel.Dock="Top" Spacing="10" Margin="5">
+            <Button Content="Patients" Command="{Binding ShowPatientsCommand}"/>
+            <Button Content="Procedures" Command="{Binding ShowProceduresCommand}"/>
+        </StackPanel>
+        <ContentControl Content="{Binding CurrentView}"/>
+    </DockPanel>
 
 </Window>

--- a/PatientApp/Views/PatientsView.axaml
+++ b/PatientApp/Views/PatientsView.axaml
@@ -1,0 +1,19 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="PatientApp.Views.PatientsView"
+             xmlns:vm="using:PatientApp.ViewModels"
+             x:DataType="vm:PatientsViewModel">
+    <StackPanel Margin="10">
+        <TextBlock Text="Patients" FontSize="20"/>
+        <ListBox ItemsSource="{Binding Patients}" SelectedIndex="0">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding FullName}"/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </StackPanel>
+</UserControl>

--- a/PatientApp/Views/PatientsView.axaml.cs
+++ b/PatientApp/Views/PatientsView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace PatientApp.Views;
+
+public partial class PatientsView : UserControl
+{
+    public PatientsView()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}

--- a/PatientApp/Views/ProceduresView.axaml
+++ b/PatientApp/Views/ProceduresView.axaml
@@ -1,0 +1,19 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="PatientApp.Views.ProceduresView"
+             xmlns:vm="using:PatientApp.ViewModels"
+             x:DataType="vm:ProceduresViewModel">
+    <StackPanel Margin="10">
+        <TextBlock Text="Procedures" FontSize="20"/>
+        <ListBox ItemsSource="{Binding Procedures}">
+            <ListBox.ItemTemplate>
+                <DataTemplate>
+                    <TextBlock Text="{Binding Name}"/>
+                </DataTemplate>
+            </ListBox.ItemTemplate>
+        </ListBox>
+    </StackPanel>
+</UserControl>

--- a/PatientApp/Views/ProceduresView.axaml.cs
+++ b/PatientApp/Views/ProceduresView.axaml.cs
@@ -1,0 +1,12 @@
+using Avalonia.Controls;
+using Avalonia.Markup.Xaml;
+
+namespace PatientApp.Views;
+
+public partial class ProceduresView : UserControl
+{
+    public ProceduresView()
+    {
+        AvaloniaXamlLoader.Load(this);
+    }
+}


### PR DESCRIPTION
## Summary
- add EF Core context and data service
- define patient, procedure and visit models
- create view models for listing and adding patients/procedures
- implement new views and navigation in main window
- update csproj with EF Core packages

## Testing
- `dotnet build PatientApp.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_688b1195b2048323959ff8578eaf72fd